### PR TITLE
Feature sanitize query multiline error

### DIFF
--- a/lib/query_hook.rb
+++ b/lib/query_hook.rb
@@ -63,10 +63,14 @@ ruby
   end
 
   def error_output?(result)
-    /\.rb:(\d)+:in `<main>': / =~ result
+    error_regexp =~ result
   end
 
   def sanitize_error_output(result)
-    result.split("<main>': ").second
+    result.gsub(error_regexp, '').strip
+  end
+
+  def error_regexp
+    /(from )?(.)+\.rb:(\d)+:in `([\w|<|>]+)'(: )?/
   end
 end

--- a/lib/query_hook.rb
+++ b/lib/query_hook.rb
@@ -74,6 +74,6 @@ ruby
     # Matches lines like:
     # * from /tmp/mumuki.compile20170404-3221-1db8ntk.rb:17:in `<main>'
     # * /tmp/mumuki.compile20170404-3221-1db8ntk.rb:17:in `respond_to?':
-    /(from )?(.)+\.rb:(\d)+:in `([\w|<|>|?|!]+)'(:)?/
+    /(from )?(.)+\.rb:(\d)+:in `([\w|<|>|?|!|+|*|-|\/|=]+)'(:)?/
   end
 end

--- a/lib/query_hook.rb
+++ b/lib/query_hook.rb
@@ -71,6 +71,9 @@ ruby
   end
 
   def error_regexp
-    /(from )?(.)+\.rb:(\d)+:in `([\w|<|>]+)'(: )?/
+    # Matches lines like:
+    # * from /tmp/mumuki.compile20170404-3221-1db8ntk.rb:17:in `<main>'
+    # * /tmp/mumuki.compile20170404-3221-1db8ntk.rb:17:in `respond_to?':
+    /(from )?(.)+\.rb:(\d)+:in `([\w|<|>|?|!]+)'(:)?/
   end
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -14,9 +14,15 @@ describe RubyQueryHook do
     it { expect(result[0]).to eq "=> 5\n" }
   end
 
-  context 'query with errors' do
+  context 'query with one line error output' do
     let(:request) { struct(query: 'true.unknown_message') }
-    it { expect(result[0]).to eq "undefined method `unknown_message' for true:TrueClass (NoMethodError)\n" }
+    it { expect(result[0]).to eq "undefined method `unknown_message' for true:TrueClass (NoMethodError)" }
+    it { expect(result[1]).to eq :failed }
+  end
+
+  context 'query with multiline error output' do
+    let(:request) { struct(query: 'true.inspect("invalid argument")') }
+    it { expect(result[0]).to eq 'wrong number of arguments (1 for 0) (ArgumentError)' }
     it { expect(result[1]).to eq :failed }
   end
 

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -15,8 +15,8 @@ describe RubyQueryHook do
   end
 
   context 'query with one line error output' do
-    let(:request) { struct(query: 'true.unknown_message') }
-    it { expect(result[0]).to eq "undefined method `unknown_message' for true:TrueClass (NoMethodError)" }
+    let(:request) { struct(query: 'true.unknown_message?') }
+    it { expect(result[0]).to eq "undefined method `unknown_message?' for true:TrueClass (NoMethodError)" }
     it { expect(result[1]).to eq :failed }
   end
 


### PR DESCRIPTION
This extends sanitization support to deal with errors like this one:
```
/tmp/mumuki.compile20170404-3028-v7fkah.rb:60:in `comer_alpiste': wrong number of arguments (2 for 1) (ArgumentError)
from /tmp/mumuki.compile20170404-3028-v7fkah.rb:85:in `<main>'
```

Sorry for the regexp magic, tried to clarify it with those comments. :crystal_ball: