### PR TITLE
Chore set original language

### DIFF
--- a/lib/expectations_hook.rb
+++ b/lib/expectations_hook.rb
@@ -7,6 +7,10 @@ class RubyExpectationsHook < Mumukit::Templates::MulangExpectationsHook
     'Mulang'
   end
 
+  def original_language
+    'Ruby'
+  end
+
   def compile_content(source)
     Mulang::Ruby.parse(source)
   rescue => e

--- a/mumuki-ruby-runner.gemspec
+++ b/mumuki-ruby-runner.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'mumukit', '~> 2.38'
+  spec.add_dependency 'mumukit', '~> 2.39'
   spec.add_dependency 'mulang-ruby', '~> 6.0'
 
   spec.add_development_dependency 'bundler', '>= 1.7', '< 3'

--- a/spec/expectations_spec.rb
+++ b/spec/expectations_spec.rb
@@ -74,6 +74,49 @@ describe RubyExpectationsHook do
       it { expect(result).to eq [{expectation: declares_foo, result: false}, {expectation: declares_pepita, result: true}] }
     end
 
+    describe 'UsesMath' do
+      let(:uses_math) { {binding: '*', inspection: 'UsesMath'} }
+      let(:uses_minus) { {binding: '*', inspection: 'Uses:-'} }
+      let(:uses_minus_operator) { {binding: '*', inspection: 'UsesMinus'} }
+      let(:returns_with_math) { {binding: '*', inspection: 'Returns:WithMath'} }
+
+      context 'when used in assignment' do
+        let(:code) { 'class Pepita; def fly!; @energy = energy - 10 end end' }
+        let(:expectations) { [uses_math, uses_minus, returns_with_math] }
+
+        it do
+          expect(result).to eq [
+              {expectation: uses_math, result: true},
+              {expectation: uses_minus_operator, result: true},
+              {expectation: returns_with_math, result: false} ]
+        end
+      end
+
+      context 'when used in implicit return' do
+        let(:code) { 'class Pepita; def required_energy; @energy - 50 end end' }
+        let(:expectations) { [uses_math, uses_minus, returns_with_math] }
+
+        it do
+          expect(result).to eq [
+              {expectation: uses_math, result: true},
+              {expectation: uses_minus_operator, result: true},
+              {expectation: returns_with_math, result: true} ]
+        end
+      end
+
+      context 'when used in explicit return' do
+        let(:code) { 'class Pepita; def required_energy; return @energy - 50 end end' }
+        let(:expectations) { [uses_math, uses_minus, returns_with_math] }
+
+        it do
+          expect(result).to eq [
+              {expectation: uses_math, result: true},
+              {expectation: uses_minus_operator, result: true},
+              {expectation: returns_with_math, result: true} ]
+        end
+      end
+    end
+
     describe 'UsesInheritance' do
       context 'when uses' do
         let(:code) { 'class Pepita < Bird; end' }


### PR DESCRIPTION
# :dart: Goal

To set original language as Ruby. That way, autocorrection rules embedded in Haskell will take effect.  