### PR TITLE
Fix if smells

### DIFF
--- a/mumuki-ruby-runner.gemspec
+++ b/mumuki-ruby-runner.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'mumukit', '~> 2.39'
+  spec.add_dependency 'mulang', '>= 6.0.5'
   spec.add_dependency 'mulang-ruby', '~> 6.1'
 
   spec.add_development_dependency 'bundler', '>= 1.7', '< 3'

--- a/spec/expectations_spec.rb
+++ b/spec/expectations_spec.rb
@@ -47,6 +47,82 @@ describe RubyExpectationsHook do
 
       it { expect(result.size).to eq 5 }
     end
+
+    describe 'if smells' do
+      let(:expectations) { [] }
+
+      describe 'HasEmptyIfBranches' do
+        let(:code) do
+          %q{
+            module FooBar
+              def self.do_foo
+                if some_condition
+                end
+              end
+            end
+          }
+        end
+
+        it { expect(result).to include expectation: {binding: "do_foo", inspection: "HasEmptyIfBranches"}, result: false }
+      end
+
+      describe 'HasEqualIfBranches' do
+        let(:code) do
+          %q{
+            module FooBar
+              def self.do_foo
+                if some_condition
+                  do_it!
+                else
+                  do_it!
+                end
+              end
+            end
+          }
+        end
+
+        it { expect(result).to include expectation: {binding: "do_foo", inspection: "HasEqualIfBranches"}, result: false }
+      end
+
+
+      describe 'HasRedundantIf' do
+        let(:code) do
+          %q{
+            module FooBar
+              def self.do_foo
+                if some_condition
+                  true
+                else
+                  false
+                end
+              end
+            end
+          }
+        end
+
+        it { expect(result).to include expectation: {binding: "do_foo", inspection: "HasRedundantIf"}, result: false }
+      end
+
+
+      describe 'ShouldInvertIfCondition' do
+        let(:code) do
+          %q{
+            module FooBar
+              def self.do_foo
+                if some_condition
+                else
+                  do_it!
+                end
+              end
+            end
+          }
+        end
+
+        it { expect(result).to include expectation: {binding: "do_foo", inspection: "ShouldInvertIfCondition"}, result: false }
+      end
+
+    end
+
     context 'no domain language smells' do
       let(:code) { 'module FooBar; def foo_bar; end; end' }
       let(:expectations) { [] }


### PR DESCRIPTION
# :dart: Goal

To allow if-related code smells to properly work, since they don't work in most scenarios

# :warning: Dependencies 

Depends on https://github.com/mumuki/mulang-ruby/pull/19